### PR TITLE
add 95% confidence interval to delta

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -494,8 +494,9 @@ fn printUnit(w: anytype, x: f64, unit: Measurement.Unit, std_dev: f64) !void {
 
 // Gets either the T or Z score for 95% confidence.
 // If no `df` variable is provided, Z score is provided.
-pub fn getStatScore95(df: ?usize) f64 {
-    if (df) |dfv| {
+pub fn getStatScore95(df: ?u64) f64 {
+    if (df) |dff| {
+        const dfv = @intCast(usize, dff);
         if (dfv <= 30) {
             return t_table95_1to30[dfv - 1];
         } else if (dfv <= 120) {


### PR DESCRIPTION
![image](https://github.com/andrewrk/poop/assets/32912555/350dd039-f140-4965-9a88-3c802790bece)
An important missing feature is a confidence interval on the delta, since insignificant run-to-run changes might wrongly show up as meaningful.

This PR adds that. Notice the `cache_misses - 3.3%`  (which would've been considered significant before) is no longer significant since the standard deviation was high.

Related to #7 and #2 

Resources:
- T-table came from the two-tailed 95% column here: https://en.wikipedia.org/wiki/Student%27s_t-distribution.
- Underlying stats described here: https://sphweb.bumc.bu.edu/otlt/mph-modules/bs/bs704_confidence_intervals/bs704_confidence_intervals5.html

