### PR TITLE
Show progress while running commands

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,7 @@ const perf_measurements = [_]PerfMeasurement{
 };
 
 const Command = struct {
+    raw_cmd: []const u8,
     argv: []const []const u8,
     measurements: Measurements,
     sample_count: usize,
@@ -89,6 +90,7 @@ pub fn main() !void {
             var cmd_argv = std.ArrayList([]const u8).init(arena);
             try parseCmd(&cmd_argv, arg);
             try commands.append(.{
+                .raw_cmd = arg,
                 .argv = try cmd_argv.toOwnedSlice(),
                 .measurements = undefined,
                 .sample_count = undefined,
@@ -112,15 +114,32 @@ pub fn main() !void {
         }
     }
 
+    var progress: std.Progress = .{};
+    const root_node = progress.start("poop", commands.items.len);
+    defer root_node.end();
+
     var perf_fds = [1]fd_t{-1} ** perf_measurements.len;
     var samples_buf: [10000]Sample = undefined;
 
     var timer = std.time.Timer.start() catch @panic("need timer to work");
 
     for (commands.items, 1..) |*command, command_n| {
+        const max_prog_name_len = 50;
+        const prog_name = blk: {
+            if (command.raw_cmd.len > max_prog_name_len) {
+                break :blk try std.fmt.allocPrint(arena, "'{s}...'", .{command.raw_cmd[0 .. max_prog_name_len - 3]});
+            }
+            break :blk try std.fmt.allocPrint(arena, "'{s}'", .{command.raw_cmd});
+        };
+        var cmd_prog_node = root_node.start(prog_name, 0);
+        cmd_prog_node.activate();
+        progress.refresh();
+
+        const min_samples = 3;
+
         const first_start = timer.read();
         var sample_index: usize = 0;
-        while ((sample_index < 3 or
+        while ((sample_index < min_samples or
             (timer.read() - first_start) < max_nano_seconds) and
             sample_index < samples_buf.len) : (sample_index += 1)
         {
@@ -184,7 +203,17 @@ pub fn main() !void {
                 std.os.close(perf_fd.*);
                 perf_fd.* = -1;
             }
+
+            cmd_prog_node.setEstimatedTotalItems(est_total: {
+                const cur_samples: u64 = sample_index + 1;
+                const ns_per_sample = (timer.read() - first_start) / cur_samples;
+                const estimate = std.math.divCeil(u64, max_nano_seconds, ns_per_sample) catch unreachable;
+                break :est_total @intCast(usize, @max(cur_samples, estimate, min_samples));
+            });
+            cmd_prog_node.completeOne();
         }
+
+        cmd_prog_node.end();
 
         const all_samples = samples_buf[0..sample_index];
 
@@ -200,6 +229,9 @@ pub fn main() !void {
         command.sample_count = all_samples.len;
 
         {
+            progress.lock_stderr();
+            defer progress.unlock_stderr();
+
             try tty_conf.setColor(stdout_w, .bold);
             try stdout_w.print("Benchmark {d}", .{command_n});
             try tty_conf.setColor(stdout_w, .dim);


### PR DESCRIPTION
Resolves: #8

Sample output while running:
```
[mlugg@polaris poop]$ ./zig-out/bin/poop 'sleep 2' 'sleep 0.3564657983425769842579824567984236947654527985'
Benchmark 1 (3 runs): sleep 2:
  measurement      mean ± σ               min … max                   outliers         delta
  wall_time        2s ± 49.11us           2s … 2s                       0 ( 0%)        0%
  peak_rss         1M ± 45K               1M … 1M                       0 ( 0%)        0%
  cpu_cycles       436236 ± 18714         414747 … 448953               0 ( 0%)        0%
  instructions     208761 ± 8             208754 … 208769               0 ( 0%)        0%
  cache_references 16577 ± 621            15934 … 17174                 0 ( 0%)        0%
  cache_misses     6299 ± 428             5877 … 6732                   0 ( 0%)        0%
  branch_misses    2882 ± 38              2840 … 2914                   0 ( 0%)        0%
poop [2/2] 'sleep 0.356465798342576984257982456798423694765...' [4/14]
```