### PR TITLE
align result columns on '±' and '…'

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -248,7 +248,6 @@ pub fn main() !void {
                 .min_max = "min".len,
                 .outliers = 0,
                 .delta = 0,
-                .delta_symbol = 0,
             };
             var align_info: [@typeInfo(Command.Measurements).Struct.fields.len]AlignInfo = undefined;
             inline for (&align_info, @typeInfo(Command.Measurements).Struct.fields) |*pad, field| {
@@ -313,7 +312,7 @@ pub fn main() !void {
 
             try tty_conf.setColor(stdout_w, .bold);
             try stdout_w.writeAll(column_separator);
-            try stdout_w.writeByteNTimes(' ', max_alignments.outliers - "max".len);
+            try stdout_w.writeByteNTimes(' ', max_alignments.outliers - "max".len - 2);
             try tty_conf.setColor(stdout_w, .bright_yellow);
             try stdout_w.writeAll("outliers");
             try tty_conf.setColor(stdout_w, .reset);
@@ -321,7 +320,7 @@ pub fn main() !void {
             if (commands.items.len >= 2) {
                 try tty_conf.setColor(stdout_w, .bold);
                 try stdout_w.writeAll(column_separator);
-                try stdout_w.writeByteNTimes(' ', max_alignments.delta + max_alignments.delta_symbol);
+                try stdout_w.writeByteNTimes(' ', max_alignments.delta);
                 try stdout_w.writeAll("delta");
                 try tty_conf.setColor(stdout_w, .reset);
             }
@@ -444,7 +443,6 @@ const AlignInfo = struct {
     mean: usize,
     min_max: usize,
     outliers: usize,
-    delta_symbol: usize,
     delta: usize,
 };
 
@@ -552,7 +550,6 @@ fn printMeasurementInner(
                     break :blk false;
                 }
             };
-            try w.writeByteNTimes(' ', align_info.delta_symbol);
             if (m.mean > f.mean) {
                 if (is_sig) {
                     try w.writeAll("💩");
@@ -595,8 +592,7 @@ fn printMeasurementInner(
     return AlignInfo{
         .mean = size_mean,
         .min_max = size_stddev + size_min,
-        .outliers = size_max,
-        .delta_symbol = size_outliers,
+        .outliers = size_max  + size_outliers,
         .delta = size_delta,
     };
 }


### PR DESCRIPTION
**NOTE:** This PR depends on ziglang/zig#16093 or an equivalent being merged.

This change aligns the output columns nicely (closes #4, maybe #10):
<pre><b>Benchmark 1 (16 runs)</b>: ls:
<b>  measurement             </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>                 </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>       </b><font color="#EBCB8B"><b>outliers</b></font><b>     delta</b>
  wall_time            <font color="#A3BE8C">1.539ms</font> ± <font color="#A3BE8C">518.139us</font>    <font color="#88C0D0">894.54us</font> … <font color="#B48EAD">2.19ms</font>    0 ( 0%)      0%
  peak_rss                  <font color="#A3BE8C">2M</font> ± <font color="#A3BE8C">55K</font>                <font color="#88C0D0">2M</font> … <font color="#B48EAD">2M</font>        0 ( 0%)      0%
  cpu_cycles            <font color="#A3BE8C">394324</font> ± <font color="#A3BE8C">34256</font>          <font color="#88C0D0">358799</font> … <font color="#B48EAD">472970</font>    0 ( 0%)      0%
  instructions          <font color="#A3BE8C">399643</font> ± <font color="#A3BE8C">33</font>             <font color="#88C0D0">399631</font> … <font color="#B48EAD">399765</font>    1 ( 6%)      0%
  cache_references       <font color="#A3BE8C">28690</font> ± <font color="#A3BE8C">1332</font>            <font color="#88C0D0">25886</font> … <font color="#B48EAD">31990</font>     <font color="#EBCB8B">3 (19%)</font>      0%
  cache_misses            <font color="#A3BE8C">9049</font> ± <font color="#A3BE8C">328</font>              <font color="#88C0D0">8704</font> … <font color="#B48EAD">9867</font>      <font color="#EBCB8B">2 (13%)</font>      0%
  branch_misses           <font color="#A3BE8C">4873</font> ± <font color="#A3BE8C">115</font>              <font color="#88C0D0">4720</font> … <font color="#B48EAD">5147</font>      1 ( 6%)      0%
<b>Benchmark 2 (12 runs)</b>: ls -R:
<b>  measurement             </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>             </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>        </b><font color="#EBCB8B"><b>outliers</b></font><b>           delta</b>
  wall_time             <font color="#A3BE8C">4.14ms</font> ± <font color="#A3BE8C">1.33ms</font>    <font color="#88C0D0">2.356ms</font> … <font color="#B48EAD">5.501ms</font>    0 ( 0%)     💩<font color="#BF616A"> +169.0% ± 48.5%</font>
  peak_rss                  <font color="#A3BE8C">2M</font> ± <font color="#A3BE8C">61K</font>            <font color="#88C0D0">2M</font> … <font color="#B48EAD">2M</font>         0 ( 0%)        +  2.0% ±  1.7%
  cpu_cycles           <font color="#A3BE8C">1594313</font> ± <font color="#A3BE8C">124837</font>    <font color="#88C0D0">1478479</font> … <font color="#B48EAD">1901268</font>    0 ( 0%)     💩<font color="#BF616A"> +304.3% ± 17.0%</font>
  instructions         <font color="#A3BE8C">2503325</font> ± <font color="#A3BE8C">50</font>        <font color="#88C0D0">2503294</font> … <font color="#B48EAD">2503435</font>    0 ( 0%)     💩<font color="#BF616A"> +526.4% ±  0.0%</font>
  cache_references      <font color="#A3BE8C">134853</font> ± <font color="#A3BE8C">3338</font>       <font color="#88C0D0">130399</font> … <font color="#B48EAD">142218</font>     0 ( 0%)     💩<font color="#BF616A"> +370.0% ±  6.6%</font>
  cache_misses           <font color="#A3BE8C">11182</font> ± <font color="#A3BE8C">635</font>         <font color="#88C0D0">10073</font> … <font color="#B48EAD">12195</font>      0 ( 0%)     💩<font color="#BF616A"> + 23.6% ±  4.2%</font>
  branch_misses          <font color="#A3BE8C">14396</font> ± <font color="#A3BE8C">323</font>         <font color="#88C0D0">14016</font> … <font color="#B48EAD">14941</font>      0 ( 0%)     💩<font color="#BF616A"> +195.4% ±  3.7%</font>
</pre>

Note that the columns of different benchmarks are no longer aligned - doing this would require either only printing results after all benchmarks have run, or making the columns wide enough that we can hope/pray the numbers fit inside them (and hence be much wider than needed when number are smaller).

Possible future improvements could be properly centering the 'outliers' and 'delta' headers.