### PR TITLE
show command stderr of failure

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -161,9 +161,14 @@ pub fn main() !void {
     var perf_fds = [1]fd_t{-1} ** perf_measurements.len;
     var samples_buf: [MAX_SAMPLES]Sample = undefined;
 
+    var stderr_buffer: [4096]u8 = undefined;
+    var stderr_fba = std.heap.FixedBufferAllocator.init(&stderr_buffer);
+
     var timer = std.time.Timer.start() catch @panic("need timer to work");
 
     for (commands.items, 1..) |*command, command_n| {
+        stderr_fba.reset();
+
         const max_prog_name_len = 50;
         const prog_name = blk: {
             if (command.raw_cmd.len > max_prog_name_len) {
@@ -206,11 +211,28 @@ pub fn main() !void {
 
             child.stdin_behavior = .Ignore;
             child.stdout_behavior = .Ignore;
-            child.stderr_behavior = .Ignore;
+            child.stderr_behavior = .Pipe;
             child.request_resource_usage_statistics = true;
 
             const start = timer.read();
             try child.spawn();
+
+            var poller = std.io.poll(stderr_fba.allocator(), enum { stderr }, .{ .stderr = child.stderr.? });
+            defer poller.deinit();
+
+            const child_stderr = poller.fifo(.stderr);
+            var stderr_truncated = false;
+
+            while (poller.poll() catch {
+                stderr_truncated = true;
+                break;
+            }) {
+                if (child_stderr.count > 2048) {
+                    stderr_truncated = true;
+                    break;
+                }
+            }
+
             const term = try child.wait();
             const end = timer.read();
             _ = std.os.linux.ioctl(perf_fds[0], PERF.EVENT_IOC.DISABLE, PERF.IOC_FLAG_GROUP);
@@ -219,7 +241,31 @@ pub fn main() !void {
             switch (term) {
                 .Exited => |code| {
                     if (code != 0) {
-                        std.debug.print("error: exit code {d}\n", .{code});
+                        bar.clear() catch {};
+                        std.debug.print("\nerror: Benchmark {d} command '{s}' failed with exit code {d}:\n", .{
+                            command_n,
+                            command.raw_cmd,
+                            code,
+                        });
+                        if (stderr_truncated) {
+                            std.debug.print(
+                                \\────────────── truncated stderr ──────────────
+                                \\{s}
+                                \\──────────────────────────────────────────────
+                                \\
+                            ,
+                                .{child_stderr.buf[child_stderr.head..][0..child_stderr.count]},
+                            );
+                        } else {
+                            std.debug.print(
+                                \\─────────────────── stderr ───────────────────
+                                \\{s}
+                                \\──────────────────────────────────────────────
+                                \\
+                            ,
+                                .{child_stderr.buf[child_stderr.head..][0..child_stderr.count]},
+                            );
+                        }
                         std.process.exit(1);
                     }
                 },


### PR DESCRIPTION
Closes #9. Here is the output for a command failing.
<pre><span style="background-color:#4C566A"><font color="#E5E9F0"><b>I </b></font></span> ~/S/<b>poop</b> (<font color="#A3BE8C">child-stderr</font> <font color="#A3BE8C">+</font>) <font color="#BF616A">[</font><font color="#BF616A"><b>1</b></font><font color="#BF616A">]</font> &gt; <font color="#81A1C1">zig-out/bin/poop</font> <font color="#ECEFF4">ls</font> <font color="#A3BE8C">&apos;ls a&apos;</font> <font color="#ECEFF4">ls</font>  <font color="#ECEFF4">-d</font> <font color="#ECEFF4">50</font>
<b>Benchmark 1 (24 runs)</b>: ls
<b>  measurement      </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>               </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>                   </b><font color="#EBCB8B"><b>outliers</b></font><b>         delta</b>
  wall_time        <font color="#A3BE8C">1.432ms</font> ± <font color="#A3BE8C">484.231us</font>    <font color="#88C0D0">773.111us</font> … <font color="#B48EAD">1.972ms</font>           0 ( 0%)        0%
  peak_rss         <font color="#A3BE8C">2M</font> ± <font color="#A3BE8C">70K</font>               <font color="#88C0D0">2M</font> … <font color="#B48EAD">2M</font>                       0 ( 0%)        0%
  cpu_cycles       <font color="#A3BE8C">387633</font> ± <font color="#A3BE8C">64478</font>         <font color="#88C0D0">354835</font> … <font color="#B48EAD">608024</font>            <font color="#EBCB8B">   3 (13%)</font>        0%
  instructions     <font color="#A3BE8C">398961</font> ± <font color="#A3BE8C">75</font>            <font color="#88C0D0">398903</font> … <font color="#B48EAD">399132</font>               0 ( 0%)        0%
  cache_references <font color="#A3BE8C">28741</font> ± <font color="#A3BE8C">509</font>            <font color="#88C0D0">27592</font> … <font color="#B48EAD">30467</font>                 2 ( 8%)        0%
  cache_misses     <font color="#A3BE8C">9038</font> ± <font color="#A3BE8C">255</font>             <font color="#88C0D0">8693</font> … <font color="#B48EAD">9953</font>                   1 ( 4%)        0%
  branch_misses    <font color="#A3BE8C">4892</font> ± <font color="#A3BE8C">124</font>             <font color="#88C0D0">4712</font> … <font color="#B48EAD">5187</font>                   0 ( 0%)        0%

error: Benchmark 2 command &apos;ls a&apos; failed with exit code 2:
─────────────────── stderr ───────────────────
ls: cannot access &apos;a&apos;: No such file or directory
──────────────────────────────────────────────
</pre>

Any benchmarks after the failed one are skipped.

I don't think it makes that much sense for `poop` to capture arbitrarily large amounts of stderr, so I think it makes sense to just truncate after a certain amount is captured. Due to the way `std.io.Poller` reads, it only really makes sense to use a power of two sized buffer - I chose 4096 for no particular reason. The way`std.io.Poller` reads means that even if there is more than 4096 bytes of stderr, any where between `4096-512+1=3585` and `4096` bytes might be read as the poller always tries to read at least 512 bytes.

If the stderr is truncated the stderr will look like this:
<pre>
────────────── stderr truncated ──────────────
ls: cannot access &apos;a&apos;: N
──────────────────────────────────────────────
</pre>
But with presumably much more output