### PR TITLE
Use metric prefixes and limit to 3 significant figures

### DIFF
--- a/src/progress.zig
+++ b/src/progress.zig
@@ -40,10 +40,14 @@ pub fn getScreenWidth(stdout: std.os.fd_t) usize {
     return @intCast(usize, winsize.ws_col);
 }
 
-const EscapeCodes = struct {
+pub const EscapeCodes = struct {
     pub const dim = "\x1b[2m";
     pub const pink = "\x1b[38;5;205m";
     pub const white = "\x1b[37m";
+    pub const red = "\x1b[31m";
+    pub const yellow = "\x1b[33m";
+    pub const green = "\x1b[32m";
+    pub const magenta = "\x1b[35m";
     pub const cyan = "\x1b[36m";
     pub const reset = "\x1b[0m";
     pub const erase_line = "\x1b[2K\r";


### PR DESCRIPTION
![image](https://github.com/andrewrk/poop/assets/32912555/76f07147-d1d8-4ba3-9fe5-dbecc1f3d11f)

This PR is the result of a spike into looking for ways to show a set amount of sigfigs.
Instead of scientific notation, I decided to try metric prefixes (T, G, M, K, etc) since it fits in with how we already display max RSS & durations.

I feel like I landed on something that looks good and communicates the info pretty well imo.
The central alignment of each of the columns comes trivially from the comptime-known sigfig limit.

There's no pressure to accept this PR if this isn't how you'd like things to be displayed, just want to make that clear. 

> _Potential future enhancement:_ I think it may be useful to color the different metric prefixes on a grayscale getting lighter as they get bigger.

Closes #28 
Related to #24 

---

Status quo for comparison:

![image](https://github.com/andrewrk/poop/assets/32912555/66c0ed92-d99f-4575-9971-f09940c47f0b)
