### PR TITLE
Update for latest Zig standard library

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -583,7 +583,7 @@ fn printMeasurement(
                 }
                 try w.writeAll("-");
             }
-            try fbs.writer().print("{d: >5.1}% ± {d: >4.1}%", .{ @fabs(diff_mean_percent), half });
+            try fbs.writer().print("{d: >5.1}% ± {d: >4.1}%", .{ @abs(diff_mean_percent), half });
             try w.writeAll(fbs.getWritten());
             count += fbs.pos;
             fbs.pos = 0;


### PR DESCRIPTION
Update to replace `fabs` with `abs`.