### PR TITLE
Update for latest Zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .zig-cache/
-zig-out/
+/zig-out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/zig-cache
-/zig-out
+.zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "poop",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .strip = b.option(bool, "strip", "strip the binary"),
@@ -38,7 +38,7 @@ pub fn build(b: *std.Build) void {
         const t = resolved_target.result;
         const rel_exe = b.addExecutable(.{
             .name = "poop",
-            .root_source_file = .{ .path = "src/main.zig" },
+            .root_source_file = b.path("src/main.zig"),
             .target = resolved_target,
             .optimize = .ReleaseSafe,
             .strip = true,


### PR DESCRIPTION
Update `.gitignore` for change to `.zig-cache` and to match top level Zig repo. Update `build.zig` for latest standard library changes.