### PR TITLE
Better error message if can't execute program

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -240,7 +240,10 @@ pub fn main() !void {
                 }
             }
 
-            const term = try child.wait();
+            const term = child.wait() catch |err| {
+                std.debug.print("\nerror: Couldn't execute {s}: {s}\n", .{ command.argv[0], @errorName(err) });
+                std.process.exit(1);
+            };
             const end = timer.read();
             _ = std.os.linux.ioctl(perf_fds[0], PERF.EVENT_IOC.DISABLE, PERF.IOC_FLAG_GROUP);
             const peak_rss = child.resource_usage_statistics.getMaxRss() orelse 0;


### PR DESCRIPTION
Without this in case poop can't exec the target the error message is not very helpful, not telling which command failed and produces a stack trace that doesn't help figuring out the issue:
```
  error: AccessDenied
  /usr/lib/zig/lib/std/process/Child.zig:423:5: 0x104ad77 in waitPosix (poop)
      return self.term.?;
      ^
  /usr/lib/zig/lib/std/process/Child.zig:300:9: 0x104adf3 in wait (poop)
          try self.waitPosix();
          ^
  /home/user/poop/src/main.zig:243:26: 0x105222a in main (poop)
              const term = try child.wait();
```
This changes the output to something more useful:
```
  error: Couldn't execute /etc: AccessDenied
```