### PR TITLE
Change @typeInfo.@"struct" to @typeInfo.Struct 

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -383,7 +383,7 @@ pub fn main() !void {
 
             try stdout_w.writeAll("\n");
 
-            inline for (@typeInfo(Command.Measurements).@"struct".fields) |field| {
+            inline for (@typeInfo(Command.Measurements).Struct.fields) |field| {
                 const measurement = @field(command.measurements, field.name);
                 const first_measurement = if (command_n == 1)
                     null


### PR DESCRIPTION
In zig *0.13* I got the below error and changed the accessor to reflect latest version of it.

❯ zig build
install
└─ install poop
   └─ zig build-exe poop Debug native 1 errors
src/main.zig:386:57: error: no field named 'struct' in union 'builtin.Type'
            inline for (@typeInfo(Command.Measurements).@"struct".fields) |field| {
                                                        ^~~~~~~~~
/home/ceyhun/programs/zig/zig-linux-x86_64-0.13.0/lib/std/builtin.zig:256:18: note: union declared here
pub const Type = union(enum) {