### PR TITLE
feat: add macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,43 @@
-name: ci
+name: CI
+
 on:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+
 jobs:
-  build:
+  exe:
     strategy:
-      fail-fast: false
       matrix:
-        target: [ x86-linux, x86_64-linux, aarch64-linux, riscv64-linux ]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: mlugg/setup-zig@v1
-      with:
-        version: master
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    - name: Build
-      run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0
 
-    - name: Archive executable
-      uses: actions/upload-artifact@v3
-      with:
-        name: poop
-        path: zig-out/bin/*
+      - name: Run exe step
+        run: sudo zig build exe -- 'zig build-exe examples/hello.zig' 'zig build-exe -O ReleaseFast examples/hello.zig'
+
+  fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0
+
+      - name: Run fmt step
+        run: zig build fmt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Zig artifacts
 .zig-cache/
-/zig-out/
+zig-out/
+
+# Project artifacts
+/hello*

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Stop flushing your performance down the drain.
 
 ## Overview
 
-This command line tool uses Linux's `perf_event_open` functionality to compare the performance of multiple commands
-with a colorful terminal user interface.
+This command line tool uses Linux's `perf` / Darwin's `kperf` functionality to compare the performance of multiple commands with a colorful terminal user interface.
 
 ![image](https://github.com/andrewrk/poop/assets/106511/6fc9d22b-f95b-46ce-8dc5-d5cecc77c226)
 
@@ -22,8 +21,6 @@ Options:
 ```
 
 ## Building from Source
-
-Tested with [Zig](https://ziglang.org/) `0.11.0-dev.3883+7166407d8`.
 
 ```
 zig build

--- a/build.zig
+++ b/build.zig
@@ -1,55 +1,105 @@
 const std = @import("std");
 
-pub fn build(b: *std.Build) void {
+pub fn build(b: *std.Build) !void {
+    const install_step = b.getInstallStep();
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "poop",
-        .root_source_file = b.path("src/main.zig"),
+    const target_os = target.result.os.tag;
+
+    const version_str = "0.2.0";
+    const version = try std.SemanticVersion.parse(version_str);
+
+    const root_source_file = b.path("src/main.zig");
+
+    // Dependencies
+    const scoop_dep_lazy = if (target_os.isDarwin()) b.lazyDependency("scoop", .{
         .target = target,
         .optimize = optimize,
-        .strip = b.option(bool, "strip", "strip the binary"),
-    });
+    }) else null;
+    const scoop_mod = if (scoop_dep_lazy) |scoop_dep| scoop_dep.module("scoop") else undefined;
 
+    // Executable
+    const exe_step = b.step("exe", "Run executable");
+
+    const exe = b.addExecutable(.{
+        .name = "poop",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = root_source_file,
+            .strip = b.option(bool, "strip", "strip the binary"),
+        }),
+    });
+    switch (target_os) {
+        .linux => {},
+        .macos => exe.root_module.addImport("scoop", scoop_mod),
+        else => std.debug.panic("Unsupported OS: {s}", .{@tagName(target_os)}),
+    }
     b.installArtifact(exe);
 
-    const release = b.step("release", "make an upstream binary release");
-    const release_targets = [_]std.Target.Query{
-        .{
-            .cpu_arch = .aarch64,
-            .os_tag = .linux,
+    const exe_run = b.addRunArtifact(exe);
+    if (b.args) |args| {
+        exe_run.addArgs(args);
+    }
+    exe_step.dependOn(&exe_run.step);
+
+    // Formatting check
+    const fmt_step = b.step("fmt", "Check formatting");
+
+    const fmt = b.addFmt(.{
+        .paths = &.{
+            "src/",
+            "examples/",
+            "build.zig",
+            "build.zig.zon",
         },
-        .{
-            .cpu_arch = .x86_64,
-            .os_tag = .linux,
-        },
-        .{
-            .cpu_arch = .x86,
-            .os_tag = .linux,
-        },
-        .{
-            .cpu_arch = .riscv64,
-            .os_tag = .linux,
-        },
-    };
-    for (release_targets) |target_query| {
-        const resolved_target = b.resolveTargetQuery(target_query);
-        const t = resolved_target.result;
-        const rel_exe = b.addExecutable(.{
-            .name = "poop",
-            .root_source_file = b.path("src/main.zig"),
-            .target = resolved_target,
-            .optimize = .ReleaseSafe,
-            .strip = true,
+        .check = true,
+    });
+    fmt_step.dependOn(&fmt.step);
+    install_step.dependOn(fmt_step);
+
+    // Binary release
+    const release = b.step("release", "Install and archive release binaries");
+
+    inline for (RELEASE_TRIPLES) |RELEASE_TRIPLE| {
+        const RELEASE_NAME = "poop-" ++ version_str ++ "-" ++ RELEASE_TRIPLE;
+        const RELEASE_EXE_ARCHIVE_BASENAME = RELEASE_NAME ++ ".tar.xz";
+
+        const release_exe = b.addExecutable(.{
+            .name = RELEASE_NAME,
+            .version = version,
+            .root_module = b.createModule(.{
+                .target = b.resolveTargetQuery(try std.Build.parseTargetQuery(.{ .arch_os_abi = RELEASE_TRIPLE })),
+                .optimize = .ReleaseSafe,
+                .root_source_file = root_source_file,
+                .strip = true,
+            }),
         });
 
-        const install = b.addInstallArtifact(rel_exe, .{});
-        install.dest_dir = .prefix;
-        install.dest_sub_path = b.fmt("{s}-{s}-{s}", .{
-            @tagName(t.cpu.arch), @tagName(t.os.tag), rel_exe.name,
-        });
+        const release_exe_install = b.addInstallArtifact(release_exe, .{});
 
-        release.dependOn(&install.step);
+        const release_exe_archive = b.addSystemCommand(&.{ "tar", "-cJf" });
+        release_exe_archive.setCwd(release_exe.getEmittedBinDirectory());
+        release_exe_archive.setEnvironmentVariable("XZ_OPT", "-9");
+        const release_exe_archive_path = release_exe_archive.addOutputFileArg(RELEASE_EXE_ARCHIVE_BASENAME);
+        release_exe_archive.addArg(release_exe.out_filename);
+        release_exe_archive.step.dependOn(&release_exe_install.step);
+
+        const release_exe_archive_install = b.addInstallFileWithDir(
+            release_exe_archive_path,
+            .{ .custom = "release" },
+            RELEASE_EXE_ARCHIVE_BASENAME,
+        );
+        release_exe_archive_install.step.dependOn(&release_exe_archive.step);
+
+        release.dependOn(&release_exe_archive_install.step);
     }
 }
+
+const RELEASE_TRIPLES = .{
+    "aarch64-linux",
+    "riscv64-linux",
+    "x86-linux",
+    "x86_64-linux",
+};

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,21 @@
+.{
+    .name = .poop,
+    .version = "0.2.0",
+    .fingerprint = 0xbb90f5c9c7a9a787, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0",
+    .dependencies = .{
+        .scoop = .{
+            .url = "git+https://codeberg.org/tensorush/scoop.git#a10ec7fa96510069c2fd6f85e0eb1790c5d7e288",
+            .hash = "scoop-0.3.0-lhAxpyHUAAAPZIz5GDPHjdPMttNO87KefT7i9Mk5AWm7",
+            .lazy = true,
+        },
+    },
+    .paths = .{
+        "src/",
+        "examples/",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+}

--- a/examples/hello.zig
+++ b/examples/hello.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn main() void {
+    std.debug.print("Hello, World!", .{});
+}


### PR DESCRIPTION
Hi, I've added macOS support with the help of `scoop`: https://codeberg.org/tensorush/scoop

Progress bar's implementation was borking output on macOS, so I removed the fancy bar printing. Here's an example output:

<img width="1319" alt="Screenshot 2025-03-23 at 19 08 54" src="https://github.com/user-attachments/assets/9d514836-c52c-4fad-ab54-92ce62c4bf23" />
