### PR TITLE
Add a friendly error message when Zig version is too old or too recent

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,3 +57,38 @@ pub fn build(b: *std.Build) void {
         release.dependOn(&install.step);
     }
 }
+
+const builtin = @import("builtin");
+comptime { // check current Zig version is compatible
+    const min: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0 }; // .pre and .build default to null
+    const max: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0 };
+    const current = builtin.zig_version;
+    if (current.order(min) == .lt) {
+        const error_message =
+            \\Your version of zig is too old ({d}.{d}.{d}).
+            \\This project requires Zig minimum version {d}.{d}.{d}.
+        ;
+        @compileError(std.fmt.comptimePrint(error_message, .{
+            current.major,
+            current.minor,
+            current.patch,
+            min.major,
+            min.minor,
+            min.patch,
+        }));
+    }
+    if (current.order(max) == .gt) {
+        const error_message =
+            \\Your version of zig is too recent ({d}.{d}.{d}).
+            \\This project requires Zig maximum version to be {d}.{d}.{d}.
+        ;
+        @compileError(std.fmt.comptimePrint(error_message, .{
+            current.major,
+            current.minor,
+            current.patch,
+            max.major,
+            max.minor,
+            max.patch,
+        }));
+    }
+}

--- a/build.zig
+++ b/build.zig
@@ -60,7 +60,7 @@ pub fn build(b: *std.Build) void {
 
 const builtin = @import("builtin");
 comptime { // check current Zig version is compatible
-    const min: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0 }; // .pre and .build default to null
+    const min: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0, .pre = "dev" }; // .pre and .build default to null
     const max: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0 };
     const current = builtin.zig_version;
     if (current.order(min) == .lt) {


### PR DESCRIPTION
Hi !

While trying to build poop from source, I encountered issues when building with Zig 0.14.1.

It seems a completely expected issue, regarding the rapid evolution of Zig. I've seen that few of the last commits actually keep poop in sync with latest Zig version.

I thought that some `comptime` code imposing bounds on which version of Zig is currently supported would help the user who tries to build from source.

I'm quite new to Zig, so there may be plenty of room to write version check in a much factorized way.

I haven't thoroughly tested max and min allowable bounds. For head of master, I can assert that building on `0.14.1` is broken. Thus, `0.15.0 <= version <= 0.15.0` seems reasonable.

I would also perfectly understand that this is not at all a good idea to enforce such bounds.

Thank you for all your work on Zig !