### PR TITLE
feat(build): ran zig init to generate a build.zig.zon for better anyzig support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .poop,
+    .version = "0.5.0",
+    .fingerprint = 0xbb90f5c9555d2c6c,
+    .minimum_zig_version = "0.15.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
This should make things easier for people using anyzig to be able to simply run `zig build` instead of `zig 0.15.0 build`.