### PR TITLE
Update Zig version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
 
 ## Building from Source
 
-Tested with [Zig](https://ziglang.org/) `0.11.0-dev.3883+7166407d8`.
+Tested with [Zig](https://ziglang.org/) `0.15.1`.
 
 ```
 zig build


### PR DESCRIPTION
I tried to build this project and tried to use the version that was mentioned in the README to catastrophic results (the build script failed because the root module is specified the new way). Then I did `git log` and saw that I didn't need to use an old version of Zig to build this.