### PR TITLE
Update Zig version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
 
 ## Building from Source
 
-Tested with [Zig](https://ziglang.org/) `0.15.1`.
+Tested with [Zig](https://ziglang.org/) `0.16.0`.
 
 ```
 zig build


### PR DESCRIPTION
The code didn't build with Zig 0.15 because of `process.Init` in the signature of `main`. It seems to work with Zig 0.16 though.